### PR TITLE
build(runtime): Update runtime to go 1.21

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: go116
+runtime: go121
 handlers:
 - url: /.*
   script: auto


### PR DESCRIPTION
go 1.16 app engine runtime is being deprecated, this upgrades to 1.21. I've deployed a manual test environment [here](https://preview-go121-dot-soon-development.ew.r.appspot.com/) and there doesn't appear to be any breaking changes affecting the build.